### PR TITLE
Refacto/config keys

### DIFF
--- a/config/aegis.php
+++ b/config/aegis.php
@@ -2,16 +2,18 @@
 
 declare(strict_types=1);
 
+use Gollumeo\Aegis\Support\ConfigKeys;
+
 return [
-    'require_header' => true,
-    'header_name' => 'Idempotency-Key',
-    'methods' => ['POST', 'PUT', 'DELETE', 'PATCH'],
-    'ttl_seconds' => 60,
-    'replay_headers_whitelist' => ['Content-Type', 'Cache-Control', 'ETag', 'Location', 'Content-Location', 'Vary'],
+    ConfigKeys::RequireHeader->value => true,
+    ConfigKeys::HeaderName->value => 'Idempotency-Key',
+    ConfigKeys::Methods->value => ['POST', 'PUT', 'DELETE', 'PATCH'],
+    ConfigKeys::TtlSeconds->value => 60,
+    ConfigKeys::ReplayWhitelist->value => ['Content-Type', 'Cache-Control', 'ETag', 'Location', 'Content-Location', 'Vary'],
     'key' => [
-        'min' => 16,
-        'max' => 120,
-        'charset' => 'A-Za-z0-9_-',
-        'required_prefix' => null,
+        ConfigKeys::KeyMin->value => 16,
+        ConfigKeys::KeyMax->value => 120,
+        ConfigKeys::KeyCharset->value => 'A-Za-z0-9_-',
+        ConfigKeys::KeyPrefix->value => null,
     ],
 ];

--- a/config/aegis.php
+++ b/config/aegis.php
@@ -5,11 +5,41 @@ declare(strict_types=1);
 use Gollumeo\Aegis\Support\ConfigKeys;
 
 return [
-    ConfigKeys::RequireHeader->value => true,
-    ConfigKeys::HeaderName->value => 'Idempotency-Key',
-    ConfigKeys::Methods->value => ['POST', 'PUT', 'DELETE', 'PATCH'],
-    ConfigKeys::TtlSeconds->value => 60,
-    ConfigKeys::ReplayWhitelist->value => ['Content-Type', 'Cache-Control', 'ETag', 'Location', 'Content-Location', 'Vary'],
+// config/aegis.php
+
+return [
+    // … other config entries …
+
+    // previously:
+    // ConfigKeys::RequireHeader->value    => true,
+    // ConfigKeys::HeaderName->value       => 'Idempotency-Key',
+    // ConfigKeys::Methods->value          => ['POST','PUT','DELETE','PATCH'],
+    // ConfigKeys::TtlSeconds->value       => 60,
+    // ConfigKeys::ReplayWhitelist->value  => [/* … */],
+
+    // now:
+    'require_header'             => true,
+    'header_name'                => 'Idempotency-Key',
+    'methods'                    => ['POST','PUT','DELETE','PATCH'],
+    'ttl_seconds'                => 60,
+    'replay_headers_whitelist'   => ['Content-Type','Cache-Control','ETag','Location','Content-Location','Vary'],
+
+    // … other config entries …
+
+    // previously:
+    // ConfigKeys::KeyMin->value     => 16,
+    // ConfigKeys::KeyMax->value     => 120,
+    // ConfigKeys::KeyCharset->value => 'A-Za-z0-9_-',
+    // ConfigKeys::KeyPrefix->value  => null,
+
+    // now:
+    'key' => [
+        'min'              => 16,
+        'max'              => 120,
+        'charset'          => 'A-Za-z0-9_-',
+        'required_prefix'  => null,
+    ],
+];
     'key' => [
         ConfigKeys::KeyMin->value => 16,
         ConfigKeys::KeyMax->value => 120,

--- a/src/Domain/Policies/EnsureIdempotencyCharset.php
+++ b/src/Domain/Policies/EnsureIdempotencyCharset.php
@@ -12,9 +12,13 @@ use Illuminate\Http\Request;
 final class EnsureIdempotencyCharset implements Insurance
 {
     /**
-     * {@inheritDoc}
+     * Validates the configured idempotency header value contains only allowed characters.
      *
-     * @throws InvalidIdempotencyCharset
+     * Retrieves the allowed character set and header name from AegisConfig, reads that header
+     * from the given request, and throws InvalidIdempotencyCharset if the value contains any
+     * characters outside the configured charset.
+     *
+     * @throws InvalidIdempotencyCharset If the header value contains disallowed characters.
      */
     public function assert(Request $request): void
     {

--- a/src/Domain/Policies/EnsureIdempotencyCharset.php
+++ b/src/Domain/Policies/EnsureIdempotencyCharset.php
@@ -6,6 +6,7 @@ namespace Gollumeo\Aegis\Domain\Policies;
 
 use Gollumeo\Aegis\Application\Contracts\Insurance;
 use Gollumeo\Aegis\Domain\Exceptions\InvalidIdempotencyCharset;
+use Gollumeo\Aegis\Support\AegisConfig;
 use Illuminate\Http\Request;
 
 final class EnsureIdempotencyCharset implements Insurance
@@ -17,16 +18,12 @@ final class EnsureIdempotencyCharset implements Insurance
      */
     public function assert(Request $request): void
     {
-        /** @var string $charset */
-        $charset = config('aegis.key.charset');
-        /** @var string $idempotencyHeaderName */
-        $idempotencyHeaderName = config('aegis.header_name');
-        /** @var string $key */
+        $charset = AegisConfig::keyCharset();
+        $idempotencyHeaderName = AegisConfig::headerName();
         $key = $request->header($idempotencyHeaderName);
 
         if (! preg_match('/^['.$charset.']+$/', $key)) {
             throw new InvalidIdempotencyCharset();
         }
-
     }
 }

--- a/src/Domain/Policies/EnsureIdempotencyHeaders.php
+++ b/src/Domain/Policies/EnsureIdempotencyHeaders.php
@@ -6,6 +6,7 @@ namespace Gollumeo\Aegis\Domain\Policies;
 
 use Gollumeo\Aegis\Application\Contracts\Insurance;
 use Gollumeo\Aegis\Domain\Exceptions\MissingIdempotencyHeader;
+use Gollumeo\Aegis\Support\AegisConfig;
 use Illuminate\Http\Request;
 
 final class EnsureIdempotencyHeaders implements Insurance
@@ -21,14 +22,12 @@ final class EnsureIdempotencyHeaders implements Insurance
      */
     public function assert(Request $request): void
     {
-        /** @var string $idempotencyHeaderName */
-        $idempotencyHeaderName = config('aegis.header_name');
+        $idempotencyHeaderName = AegisConfig::headerName();
         if (! $request->headers->has($idempotencyHeaderName)) {
             throw new MissingIdempotencyHeader();
         }
 
-        /** @var string $headers */
-        $headers = $request->headers->get($idempotencyHeaderName);
+        $headers = $request->headers->get($idempotencyHeaderName) ?? '';
         if (mb_trim($headers) === '') {
             throw new MissingIdempotencyHeader();
         }

--- a/src/Domain/Policies/EnsureIdempotencyKeyLength.php
+++ b/src/Domain/Policies/EnsureIdempotencyKeyLength.php
@@ -12,11 +12,16 @@ use Illuminate\Http\Request;
 final class EnsureIdempotencyKeyLength implements Insurance
 {
     /**
-     * Validates the idempotency key length in the request headers based on the predefined minimum and maximum charset configurations.
+     * Ensure the request contains an idempotency key whose length falls within configured bounds.
      *
-     * @param  Request  $request  The incoming HTTP request containing the headers to be validated.
+     * Retrieves the header name and allowed minimum/maximum lengths from AegisConfig, reads the
+     * header value (defaults to an empty string if missing), and validates its length using
+     * multibyte-safe string length. If the length is less than the configured minimum or greater
+     * than the configured maximum, an InvalidIdempotencyKeyLength exception is thrown.
      *
-     * @throws InvalidIdempotencyKeyLength If the idempotency key length is outside the allowed range.
+     * @param Request $request The incoming HTTP request to validate.
+     *
+     * @throws InvalidIdempotencyKeyLength When the idempotency key length is outside the allowed range.
      */
     public function assert(Request $request): void
     {

--- a/src/Domain/Policies/EnsureIdempotencyKeyLength.php
+++ b/src/Domain/Policies/EnsureIdempotencyKeyLength.php
@@ -6,6 +6,7 @@ namespace Gollumeo\Aegis\Domain\Policies;
 
 use Gollumeo\Aegis\Application\Contracts\Insurance;
 use Gollumeo\Aegis\Domain\Exceptions\InvalidIdempotencyKeyLength;
+use Gollumeo\Aegis\Support\AegisConfig;
 use Illuminate\Http\Request;
 
 final class EnsureIdempotencyKeyLength implements Insurance
@@ -19,16 +20,12 @@ final class EnsureIdempotencyKeyLength implements Insurance
      */
     public function assert(Request $request): void
     {
-        /** @var int $minCharset */
-        $minCharset = config('aegis.key.min');
-        /** @var int $maxCharset */
-        $maxCharset = config('aegis.key.max');
-        /** @var string $idempotencyHeaderName */
-        $idempotencyHeaderName = config('aegis.header_name');
-        /** @var string $headers */
-        $headers = $request->headers->get($idempotencyHeaderName);
+        $minKeyLength = AegisConfig::keyMin();
+        $maxKeyLength = AegisConfig::keyMax();
+        $headerName = AegisConfig::headerName();
+        $headers = $request->headers->get($headerName) ?? '';
 
-        if (mb_strlen($headers) < $minCharset || mb_strlen($headers) > $maxCharset) {
+        if (mb_strlen($headers) < $minKeyLength || mb_strlen($headers) > $maxKeyLength) {
             throw new InvalidIdempotencyKeyLength();
         }
     }

--- a/src/Domain/Policies/EnsureIdempotencyKeyPrefix.php
+++ b/src/Domain/Policies/EnsureIdempotencyKeyPrefix.php
@@ -14,8 +14,10 @@ use function mb_strlen;
 final class EnsureIdempotencyKeyPrefix implements Insurance
 {
     /**
-     * Ensures that the Idempotency-Key header starts with the configured prefix when required.
-     * Single-key config: aegis.key.required_prefix holds the prefix string. When null or empty, enforcement is disabled.
+     * Ensures the request's Idempotency-Key header starts with the configured prefix when enforcement is enabled.
+     *
+     * If the configured prefix is empty or null, no validation is performed. If the header is missing or does not start
+     * with the required prefix, throws InvalidIdempotencyKeyPrefix.
      *
      * @throws InvalidIdempotencyKeyPrefix
      */

--- a/src/Support/AegisConfig.php
+++ b/src/Support/AegisConfig.php
@@ -38,6 +38,17 @@ final readonly class AegisConfig
         return $ttlSeconds;
     }
 
+    /**
+     * @return string[]
+     */
+    public static function replayHeadersWhitelist(): array
+    {
+        /** @var string[] $replayWhiteList */
+        $replayWhiteList = config(ConfigKeys::ReplayWhitelist->value);
+
+        return $replayWhiteList;
+    }
+
     public static function keyMin(): int
     {
         /** @var int $keyMin */

--- a/src/Support/AegisConfig.php
+++ b/src/Support/AegisConfig.php
@@ -30,6 +30,14 @@ final readonly class AegisConfig
         return $methods;
     }
 
+    /**
+     * Get the configured time-to-live in seconds.
+     *
+     * Reads the value at the configuration key represented by ConfigKeys::TtlSeconds
+     * and returns it cast to an int.
+     *
+     * @return int The TTL in seconds.
+     */
     public static function ttlSeconds(): int
     {
         /** @var int $ttlSeconds */
@@ -39,7 +47,12 @@ final readonly class AegisConfig
     }
 
     /**
-     * @return string[]
+     * Return the replay headers whitelist from configuration.
+     *
+     * Reads the ConfigKeys::ReplayWhitelist configuration value and returns it as
+     * an array of header names (strings) that should be allowed for replay checks.
+     *
+     * @return string[] Array of header names from the `replay_whitelist` config entry.
      */
     public static function replayHeadersWhitelist(): array
     {
@@ -49,6 +62,13 @@ final readonly class AegisConfig
         return $replayWhiteList;
     }
 
+    /**
+     * Get the configured minimum key length.
+     *
+     * Reads the value at ConfigKeys::KeyMin and returns it as an int.
+     *
+     * @return int The minimum allowed key length from configuration.
+     */
     public static function keyMin(): int
     {
         /** @var int $keyMin */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,6 +21,17 @@ abstract class TestCase extends Orchestra
         ];
     }
 
+    /**
+     * Configure package-specific environment settings for tests.
+     *
+     * Sets Aegis configuration values (using ConfigKeys enum values) required by tests:
+     * - require header enforcement
+     * - header name
+     * - HTTP methods to protect
+     * - idempotency key length range, charset and prefix
+     *
+     * The configuration is applied to the test application container via the global config helper.
+     */
     protected function defineEnvironment($app): void
     {
         config([ConfigKeys::RequireHeader->value => true]);
@@ -32,6 +43,11 @@ abstract class TestCase extends Orchestra
         config([ConfigKeys::KeyPrefix->value => 'Prefix']);
     }
 
+    /**
+     * Register test routes for the application.
+     *
+     * Defines a POST /payments endpoint handled by DummyController::pay and protected by the 'aegis' middleware.
+     */
     protected function defineRoutes(mixed $router): void
     {
         $router->post('/payments', [DummyController::class, 'pay'])->middleware('aegis');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gollumeo\Aegis\Tests;
 
 use Gollumeo\Aegis\AegisServiceProvider;
+use Gollumeo\Aegis\Support\ConfigKeys;
 use Gollumeo\Aegis\Tests\Fakes\Controllers\DummyController;
 use Orchestra\Testbench\TestCase as Orchestra;
 
@@ -22,13 +23,13 @@ abstract class TestCase extends Orchestra
 
     protected function defineEnvironment($app): void
     {
-        config(['aegis.require_header' => true]);
-        config(['aegis.header_name' => 'Idempotency-Key']);
-        config(['aegis.methods' => ['POST', 'PUT', 'PATCH', 'DELETE']]);
-        config(['aegis.key.min' => 16]);
-        config(['aegis.key.max' => 120]);
-        config(['aegis.key.charset' => 'A-Za-z0-9_-']);
-        config(['aegis.key.required_prefix' => 'Prefix']);
+        config([ConfigKeys::RequireHeader->value => true]);
+        config([ConfigKeys::HeaderName->value => 'Idempotency-Key']);
+        config([ConfigKeys::Methods->value => ['POST', 'PUT', 'PATCH', 'DELETE']]);
+        config([ConfigKeys::KeyMin->value => 16]);
+        config([ConfigKeys::KeyMax->value => 120]);
+        config([ConfigKeys::KeyCharset->value => 'A-Za-z0-9_-']);
+        config([ConfigKeys::KeyPrefix->value => 'Prefix']);
     }
 
     protected function defineRoutes(mixed $router): void

--- a/tests/Unit/IdempotencyPolicyTest.php
+++ b/tests/Unit/IdempotencyPolicyTest.php
@@ -10,6 +10,7 @@ use Gollumeo\Aegis\Domain\Policies\EnsureIdempotencyCharset;
 use Gollumeo\Aegis\Domain\Policies\EnsureIdempotencyHeaders;
 use Gollumeo\Aegis\Domain\Policies\EnsureIdempotencyKeyLength;
 use Gollumeo\Aegis\Domain\Policies\EnsureIdempotencyKeyPrefix;
+use Gollumeo\Aegis\Support\AegisConfig;
 use Illuminate\Http\Request;
 
 describe('Unit: Idempotency Policy', function (): void {
@@ -28,8 +29,7 @@ describe('Unit: Idempotency Policy', function (): void {
     it('fails if the Idempotency-Key header is invalid', function (): void {
         $insurance = new EnsureIdempotencyHeaders();
         $request = Request::create('/payments', 'POST');
-        /** @var string $aegisHeaderName */
-        $aegisHeaderName = config('aegis.header_name');
+        $aegisHeaderName = AegisConfig::headerName();
         $request->headers->set($aegisHeaderName, '');
 
         expect(
@@ -44,8 +44,7 @@ describe('Unit: Idempotency Policy', function (): void {
     it('succeeds if the Idempotency-Key header is correct', function (): void {
         $insurance = new EnsureIdempotencyHeaders();
         $request = Request::create('/payments', 'POST');
-        /** @var string $aegisHeaderName */
-        $aegisHeaderName = config('aegis.header_name');
+        $aegisHeaderName = AegisConfig::headerName();
         $request->headers->set($aegisHeaderName, '123');
 
         expect(
@@ -59,8 +58,7 @@ describe('Unit: Idempotency Policy', function (): void {
     it('fails if the Idempotency-Key header length is too short', function (): void {
         $insurance = new EnsureIdempotencyKeyLength();
         $request = Request::create('/payments', 'POST');
-        /** @var string $aegisHeaderName */
-        $aegisHeaderName = config('aegis.header_name');
+        $aegisHeaderName = AegisConfig::headerName();
         $request->headers->set($aegisHeaderName, '123');
 
         expect(
@@ -73,10 +71,8 @@ describe('Unit: Idempotency Policy', function (): void {
 
     it('fails if the Idempotency-Key length is too long', function (): void {
         $insurance = new EnsureIdempotencyKeyLength();
-        /** @var string $aegisHeaderName */
-        $aegisHeaderName = config('aegis.header_name');
-        /** @var int $maxKeyLength */
-        $maxKeyLength = config('aegis.key.max');
+        $aegisHeaderName = AegisConfig::headerName();
+        $maxKeyLength = AegisConfig::keyMax();
         $randomLongKey = str_repeat('a', $maxKeyLength + 1);
         $request = Request::create('/payments', 'POST');
         $request->headers->set($aegisHeaderName, $randomLongKey);
@@ -91,8 +87,7 @@ describe('Unit: Idempotency Policy', function (): void {
 
     it('succeeds if the Idempotency-Key length is correct', function (): void {
         $insurance = new EnsureIdempotencyKeyLength();
-        /** @var string $aegisHeaderName */
-        $aegisHeaderName = config('aegis.header_name');
+        $aegisHeaderName = AegisConfig::headerName();
         $request = Request::create('/payments', 'POST');
         $request->headers->set($aegisHeaderName, '123456-789-azerzerzd');
 
@@ -106,8 +101,7 @@ describe('Unit: Idempotency Policy', function (): void {
 
     it('fails if the Idempotency-Key charset is invalid', function (): void {
         $insurance = new EnsureIdempotencyCharset();
-        /** @var string $aegisHeaderName */
-        $aegisHeaderName = config('aegis.header_name');
+        $aegisHeaderName = AegisConfig::headerName();
         $request = Request::create('/payments', 'POST');
         $request->headers->set($aegisHeaderName, '!!!');
 
@@ -128,8 +122,7 @@ describe('Unit: Idempotency Policy', function (): void {
 
     it('succeeds if the Idempotency-Key charset is correct', function (): void {
         $insurance = new EnsureIdempotencyCharset();
-        /** @var string $aegisHeaderName */
-        $aegisHeaderName = config('aegis.header_name');
+        $aegisHeaderName = AegisConfig::headerName();
         $request = Request::create('/payments', 'POST');
         $request->headers->set($aegisHeaderName, '123456-azerzerzd');
 
@@ -143,8 +136,7 @@ describe('Unit: Idempotency Policy', function (): void {
 
     it('fails if Idempotency-Key prefix is invalid when it is required', function (): void {
         $insurance = new EnsureIdempotencyKeyPrefix();
-        /** @var string $aegisHeaderName */
-        $aegisHeaderName = config('aegis.header_name');
+        $aegisHeaderName = AegisConfig::headerName();
         $request = Request::create('/payments', 'POST');
         $request->headers->set($aegisHeaderName, 'Other-abc');
 
@@ -157,9 +149,7 @@ describe('Unit: Idempotency Policy', function (): void {
     });
     it('succeeds if Idempotency-Key prefix is valid when it is required', function (): void {
         $insurance = new EnsureIdempotencyKeyPrefix();
-        /** @var string $aegisHeaderName */
-        $aegisHeaderName = config('aegis.header_name');
-
+        $aegisHeaderName = AegisConfig::headerName();
         $request = Request::create('/payments', 'POST');
         // TestCase config sets required_prefix to 'Prefix'
         $request->headers->set($aegisHeaderName, 'Prefix-abc');
@@ -176,8 +166,7 @@ describe('Unit: Idempotency Policy', function (): void {
         config(['aegis.key.required_prefix' => null]);
         $insurance = new EnsureIdempotencyKeyPrefix();
         $request = Request::create('/payments', 'POST');
-        /** @var string $aegisHeaderName */
-        $aegisHeaderName = config('aegis.header_name');
+        $aegisHeaderName = AegisConfig::headerName();
         // Using a key not starting with the previous prefix to ensure it would fail if enabled
         $request->headers->set($aegisHeaderName, 'Other-abc');
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Idempotency key prefix is now optional; prefix validation is skipped when not configured.
  - Adds configurable replay-headers whitelist to control which headers are returned on idempotent responses.

- Refactor
  - Configuration access and key naming standardized and centralized for more consistent behavior without changing defaults.

- Tests
  - Unit and integration tests updated to use the new configuration access patterns and routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->